### PR TITLE
fix podInformer FilterFunc bug

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -18,7 +18,6 @@ package cache
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -250,10 +249,12 @@ func newSchedulerCache(config *rest.Config, schedulerName string, defaultQueue s
 				switch obj.(type) {
 				case *v1.Pod:
 					pod := obj.(*v1.Pod)
-					if strings.Compare(pod.Spec.SchedulerName, schedulerName) == 0 && pod.Status.Phase == v1.PodPending {
-						return true
+					if !responsibleForPod(pod, schedulerName) {
+						if len(pod.Spec.NodeName) == 0 {
+							return false
+						}
 					}
-					return pod.Status.Phase != v1.PodPending
+					return true
 				default:
 					return false
 				}

--- a/pkg/scheduler/cache/util.go
+++ b/pkg/scheduler/cache/util.go
@@ -58,3 +58,8 @@ func createShadowPodGroup(pod *v1.Pod) *v1alpha1.PodGroup {
 		},
 	}
 }
+
+// responsibleForPod returns true if the pod has asked to be scheduled by the given scheduler.
+func responsibleForPod(pod *v1.Pod, schedulerName string) bool {
+	return schedulerName == pod.Spec.SchedulerName
+}


### PR DESCRIPTION
If pod is scheduled by other scheduler and its phase is pending, we should update the cache otherwise kube-batch will schedule pod onto the node that has not sufficient resources and the pod will be rejected by kubelet. 

/assign @k82cn