### PR TITLE
Ignore nodes if out of syc.

### DIFF
--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -56,6 +56,7 @@ func TestNodeInfo_AddPod(t *testing.T) {
 				Releasing:   EmptyResource(),
 				Allocatable: buildResource("8000m", "10G"),
 				Capability:  buildResource("8000m", "10G"),
+				State:       NodeState{Phase: Ready},
 				Tasks: map[TaskID]*TaskInfo{
 					"c1/p1": NewTaskInfo(case01Pod1),
 					"c1/p2": NewTaskInfo(case01Pod2),
@@ -106,6 +107,7 @@ func TestNodeInfo_RemovePod(t *testing.T) {
 				Releasing:   EmptyResource(),
 				Allocatable: buildResource("8000m", "10G"),
 				Capability:  buildResource("8000m", "10G"),
+				State:       NodeState{Phase: Ready},
 				Tasks: map[TaskID]*TaskInfo{
 					"c1/p1": NewTaskInfo(case01Pod1),
 					"c1/p3": NewTaskInfo(case01Pod3),

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -78,6 +78,27 @@ func (ts TaskStatus) String() string {
 	}
 }
 
+// NodePhase defines the phase of node
+type NodePhase int
+
+const (
+	// Ready means the node is ready for scheduling
+	Ready NodePhase = 1 << iota
+	// NotReady means the node is not ready for scheduling
+	NotReady
+)
+
+func (np NodePhase) String() string {
+	switch np {
+	case Ready:
+		return "Ready"
+	case NotReady:
+		return "NotReady"
+	}
+
+	return "Unknown"
+}
+
 // validateStatusUpdate validates whether the status transfer is valid.
 func validateStatusUpdate(oldStatus, newStatus TaskStatus) error {
 	return nil

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -549,6 +549,10 @@ func (sc *SchedulerCache) Snapshot() *kbapi.ClusterInfo {
 	}
 
 	for _, value := range sc.Nodes {
+		if !value.Ready() {
+			continue
+		}
+
 		snapshot.Nodes[value.Name] = value.Clone()
 	}
 


### PR DESCRIPTION
Signed-off-by: Da K. Ma <klaus1982.cn@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes-sigs/kube-batch#861

When kubelet was restarted, the device plugin may not report resource in time; so the volcano-sh/scheduler need ignore such kind of node to avoid panic.

The default scheduler does not have such kind of issue as there's not resources usage in node info.

**Release note**:
```release-note
None
```

