### PR TITLE
Performance improvement

### DIFF
--- a/cmd/kube-batch/app/options/options.go
+++ b/cmd/kube-batch/app/options/options.go
@@ -28,6 +28,9 @@ const (
 	defaultSchedulerPeriod = time.Second
 	defaultQueue           = "default"
 	defaultListenAddress   = ":8080"
+
+	defaultQPS   = 50.0
+	defaultBurst = 100
 )
 
 // ServerOption is the main context object for the controller manager.
@@ -43,6 +46,8 @@ type ServerOption struct {
 	PrintVersion         bool
 	ListenAddress        string
 	EnablePriorityClass  bool
+	KubeAPIBurst         int
+	KubeAPIQPS           float32
 }
 
 // ServerOpts server options
@@ -71,6 +76,8 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ListenAddress, "listen-address", defaultListenAddress, "The address to listen on for HTTP requests.")
 	fs.BoolVar(&s.EnablePriorityClass, "priority-class", true,
 		"Enable PriorityClass to provide the capacity of preemption at pod group level; to disable it, set it false")
+	fs.Float32Var(&s.KubeAPIQPS, "kube-api-qps", defaultQPS, "QPS to use while talking with kubernetes apiserver")
+	fs.IntVar(&s.KubeAPIBurst, "kube-api-burst", defaultBurst, "Burst to use while talking with kubernetes apiserver")
 }
 
 // CheckOptionOrDie check lock-object-namespace when LeaderElection is enabled

--- a/cmd/kube-batch/app/options/options_test.go
+++ b/cmd/kube-batch/app/options/options_test.go
@@ -41,6 +41,8 @@ func TestAddFlags(t *testing.T) {
 		SchedulePeriod: 5 * time.Minute,
 		DefaultQueue:   defaultQueue,
 		ListenAddress:  defaultListenAddress,
+		KubeAPIBurst:   defaultBurst,
+		KubeAPIQPS:     defaultQPS,
 	}
 
 	if !reflect.DeepEqual(expected, s) {

--- a/cmd/kube-batch/app/server.go
+++ b/cmd/kube-batch/app/server.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"time"
 

--- a/cmd/kube-batch/app/server.go
+++ b/cmd/kube-batch/app/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"time"
 
@@ -52,11 +53,24 @@ const (
 	apiVersion    = "v1alpha1"
 )
 
-func buildConfig(master, kubeconfig string) (*rest.Config, error) {
+func buildConfig(opt *options.ServerOption) (*rest.Config, error) {
+	var cfg *rest.Config
+	var err error
+
+	master := opt.Master
+	kubeconfig := opt.Kubeconfig
 	if master != "" || kubeconfig != "" {
-		return clientcmd.BuildConfigFromFlags(master, kubeconfig)
+		cfg, err = clientcmd.BuildConfigFromFlags(master, kubeconfig)
+	} else {
+		cfg, err = rest.InClusterConfig()
 	}
-	return rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	cfg.QPS = opt.KubeAPIQPS
+	cfg.Burst = opt.KubeAPIBurst
+
+	return cfg, nil
 }
 
 // Run the kubeBatch scheduler
@@ -65,7 +79,7 @@ func Run(opt *options.ServerOption) error {
 		version.PrintVersionAndExit(apiVersion)
 	}
 
-	config, err := buildConfig(opt.Master, opt.Kubeconfig)
+	config, err := buildConfig(opt)
 	if err != nil {
 		return err
 	}

--- a/cmd/kube-batch/main.go
+++ b/cmd/kube-batch/main.go
@@ -21,6 +21,9 @@ import (
 	"runtime"
 	"time"
 
+	// init pprof server
+	_ "net/http/pprof"
+
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 

--- a/cmd/kube-batch/main.go
+++ b/cmd/kube-batch/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/golang/glog"
@@ -37,6 +38,8 @@ import (
 var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
 
 func main() {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
 	s := options.NewServerOption()
 	s.AddFlags(pflag.CommandLine)
 	s.RegisterOptions()

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -154,7 +154,7 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 				break
 			}
 
-			nodeScores := util.PrioritizeNodes(task, predicateNodes, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)
+			nodeScores := util.PrioritizeNodes(task, predicateNodes, ssn.BatchNodeOrderFn, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)
 
 			node := util.SelectBestNode(nodeScores)
 			// Allocate idle resource to the task.

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -52,6 +52,10 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 		if job.PodGroup.Status.Phase == v1alpha1.PodGroupPending {
 			continue
 		}
+		if vr := ssn.JobValid(job); vr != nil && !vr.Pass {
+			glog.V(4).Infof("Job <%s/%s> Queue <%s> skip allocate, reason: %v, message %v", job.Namespace, job.Name, job.Queue, vr.Reason, vr.Message)
+			continue
+		}
 
 		if queue, found := ssn.Queues[job.Queue]; found {
 			queues.Push(queue)

--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -47,6 +47,10 @@ func (alloc *backfillAction) Execute(ssn *framework.Session) {
 		if job.PodGroup.Status.Phase == v1alpha1.PodGroupPending {
 			continue
 		}
+		if vr := ssn.JobValid(job); vr != nil && !vr.Pass {
+			glog.V(4).Infof("Job <%s/%s> Queue <%s> skip backfill, reason: %v, message %v", job.Namespace, job.Name, job.Queue, vr.Reason, vr.Message)
+			continue
+		}
 
 		for _, task := range job.TaskStatusIndex[api.Pending] {
 			if task.InitResreq.IsEmpty() {

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -56,6 +56,10 @@ func (alloc *preemptAction) Execute(ssn *framework.Session) {
 		if job.PodGroup.Status.Phase == v1alpha1.PodGroupPending {
 			continue
 		}
+		if vr := ssn.JobValid(job); vr != nil && !vr.Pass {
+			glog.V(4).Infof("Job <%s/%s> Queue <%s> skip preemption, reason: %v, message %v", job.Namespace, job.Name, job.Queue, vr.Reason, vr.Message)
+			continue
+		}
 
 		if queue, found := ssn.Queues[job.Queue]; !found {
 			continue

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -190,7 +190,7 @@ func preempt(
 
 	predicateNodes := util.PredicateNodes(preemptor, allNodes, ssn.PredicateFn)
 
-	nodeScores := util.PrioritizeNodes(preemptor, predicateNodes, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)
+	nodeScores := util.PrioritizeNodes(preemptor, predicateNodes, ssn.BatchNodeOrderFn, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)
 
 	selectedNodes := util.SortNodes(nodeScores)
 	for _, node := range selectedNodes {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -57,6 +57,10 @@ func (alloc *reclaimAction) Execute(ssn *framework.Session) {
 		if job.PodGroup.Status.Phase == v1alpha1.PodGroupPending {
 			continue
 		}
+		if vr := ssn.JobValid(job); vr != nil && !vr.Pass {
+			glog.V(4).Infof("Job <%s/%s> Queue <%s> skip reclaim, reason: %v, message %v", job.Namespace, job.Name, job.Queue, vr.Reason, vr.Message)
+			continue
+		}
 
 		if queue, found := ssn.Queues[job.Queue]; !found {
 			glog.Errorf("Failed to find Queue <%s> for Job <%s/%s>",

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -302,7 +302,7 @@ func (ji *JobInfo) Clone() *JobInfo {
 		NodesFitDelta: make(NodeResourceMap),
 
 		PDB:      ji.PDB,
-		PodGroup: ji.PodGroup,
+		PodGroup: ji.PodGroup.DeepCopy(),
 
 		TaskStatusIndex: map[TaskStatus]tasksMap{},
 		Tasks:           tasksMap{},

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -132,6 +132,9 @@ type EvictableFn func(*TaskInfo, []*TaskInfo) []*TaskInfo
 // NodeOrderFn is the func declaration used to get priority score for a node for a particular task.
 type NodeOrderFn func(*TaskInfo, *NodeInfo) (float64, error)
 
+// BatchNodeOrderFn is the func declaration used to get priority score for ALL nodes for a particular task.
+type BatchNodeOrderFn func(*TaskInfo, []*NodeInfo) (map[string]float64, error)
+
 // NodeMapFn is the func declaration used to get priority score for a node for a particular task.
 type NodeMapFn func(*TaskInfo, *NodeInfo) (float64, error)
 

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -147,6 +147,31 @@ type defaultStatusUpdater struct {
 	kbclient   *kbver.Clientset
 }
 
+// following the same logic as podutil.UpdatePodCondition
+func podConditionHaveUpdate(status *v1.PodStatus, condition *v1.PodCondition) bool {
+	lastTransitionTime := metav1.Now()
+	// Try to find this pod condition.
+	_, oldCondition := podutil.GetPodCondition(status, condition.Type)
+
+	if oldCondition == nil {
+		// We are adding new pod condition.
+		return true
+	}
+	// We are updating an existing condition, so we need to check if it has changed.
+	if condition.Status == oldCondition.Status {
+		lastTransitionTime = oldCondition.LastTransitionTime
+	}
+
+	isEqual := condition.Status == oldCondition.Status &&
+		condition.Reason == oldCondition.Reason &&
+		condition.Message == oldCondition.Message &&
+		condition.LastProbeTime.Equal(&oldCondition.LastProbeTime) &&
+		lastTransitionTime.Equal(&oldCondition.LastTransitionTime)
+
+	// Return true if one of the fields have changed.
+	return !isEqual
+}
+
 // UpdatePodCondition will Update pod with podCondition
 func (su *defaultStatusUpdater) UpdatePodCondition(pod *v1.Pod, condition *v1.PodCondition) (*v1.Pod, error) {
 	glog.V(3).Infof("Updating pod condition for %s/%s to (%s==%s)", pod.Namespace, pod.Name, condition.Type, condition.Status)
@@ -460,19 +485,27 @@ func (sc *SchedulerCache) BindVolumes(task *api.TaskInfo) error {
 
 // taskUnschedulable updates pod status of pending task
 func (sc *SchedulerCache) taskUnschedulable(task *api.TaskInfo, message string) error {
-	pod := task.Pod.DeepCopy()
+	pod := task.Pod
 
-	// The reason field in 'Events' should be "FailedScheduling", there is not constants defined for this in
-	// k8s core, so using the same string here.
-	// The reason field in PodCondition should be "Unschedulable"
-	sc.Recorder.Eventf(pod, v1.EventTypeWarning, "FailedScheduling", message)
-	if _, err := sc.StatusUpdater.UpdatePodCondition(pod, &v1.PodCondition{
+	condition := &v1.PodCondition{
 		Type:    v1.PodScheduled,
 		Status:  v1.ConditionFalse,
 		Reason:  v1.PodReasonUnschedulable,
 		Message: message,
-	}); err != nil {
-		return err
+	}
+
+	if podConditionHaveUpdate(&pod.Status, condition) {
+		pod = pod.DeepCopy()
+
+		// The reason field in 'Events' should be "FailedScheduling", there is not constants defined for this in
+		// k8s core, so using the same string here.
+		// The reason field in PodCondition should be "Unschedulable"
+		sc.Recorder.Eventf(pod, v1.EventTypeWarning, "FailedScheduling", message)
+		if _, err := sc.StatusUpdater.UpdatePodCondition(pod, condition); err != nil {
+			return err
+		}
+	} else {
+		glog.V(4).Infof("task unscheduleable %s/%s, message: %s, skip by no condition update", pod.Namespace, pod.Name, message)
 	}
 
 	return nil
@@ -557,6 +590,30 @@ func (sc *SchedulerCache) Snapshot() *kbapi.ClusterInfo {
 		snapshot.Queues[value.UID] = value.Clone()
 	}
 
+	var cloneJobLock sync.Mutex
+	var wg sync.WaitGroup
+
+	cloneJob := func(value *api.JobInfo) {
+		if value.PodGroup != nil {
+			value.Priority = sc.defaultPriority
+
+			priName := value.PodGroup.Spec.PriorityClassName
+			if priorityClass, found := sc.PriorityClasses[priName]; found {
+				value.Priority = priorityClass.Value
+			}
+
+			glog.V(4).Infof("The priority of job <%s/%s> is <%s/%d>",
+				value.Namespace, value.Name, priName, value.Priority)
+		}
+
+		clonedJob := value.Clone()
+
+		cloneJobLock.Lock()
+		snapshot.Jobs[value.UID] = clonedJob
+		cloneJobLock.Unlock()
+		wg.Done()
+	}
+
 	for _, value := range sc.Jobs {
 		// If no scheduling spec, does not handle it.
 		if value.PodGroup == nil && value.PDB == nil {
@@ -572,20 +629,10 @@ func (sc *SchedulerCache) Snapshot() *kbapi.ClusterInfo {
 			continue
 		}
 
-		if value.PodGroup != nil {
-			value.Priority = sc.defaultPriority
-
-			priName := value.PodGroup.Spec.PriorityClassName
-			if priorityClass, found := sc.PriorityClasses[priName]; found {
-				value.Priority = priorityClass.Value
-			}
-
-			glog.V(4).Infof("The priority of job <%s/%s> is <%s/%d>",
-				value.Namespace, value.Name, priName, value.Priority)
-		}
-
-		snapshot.Jobs[value.UID] = value.Clone()
+		wg.Add(1)
+		go cloneJob(value)
 	}
+	wg.Wait()
 
 	glog.V(3).Infof("There are <%d> Jobs, <%d> Queues and <%d> Nodes in total for scheduling.",
 		len(snapshot.Jobs), len(snapshot.Queues), len(snapshot.Nodes))

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -460,9 +460,6 @@ func (sc *SchedulerCache) BindVolumes(task *api.TaskInfo) error {
 
 // taskUnschedulable updates pod status of pending task
 func (sc *SchedulerCache) taskUnschedulable(task *api.TaskInfo, message string) error {
-	sc.Mutex.Lock()
-	defer sc.Mutex.Unlock()
-
 	pod := task.Pod.DeepCopy()
 
 	// The reason field in 'Events' should be "FailedScheduling", there is not constants defined for this in
@@ -658,8 +655,8 @@ func (sc *SchedulerCache) RecordJobStatusEvent(job *kbapi.JobInfo) {
 }
 
 // UpdateJobStatus update the status of job and its tasks.
-func (sc *SchedulerCache) UpdateJobStatus(job *kbapi.JobInfo) (*kbapi.JobInfo, error) {
-	if !shadowPodGroup(job.PodGroup) {
+func (sc *SchedulerCache) UpdateJobStatus(job *kbapi.JobInfo, updatePG bool) (*kbapi.JobInfo, error) {
+	if updatePG && !shadowPodGroup(job.PodGroup) {
 		pg, err := sc.StatusUpdater.UpdatePodGroup(job.PodGroup)
 		if err != nil {
 			return nil, err

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -46,7 +46,7 @@ type Cache interface {
 	RecordJobStatusEvent(job *api.JobInfo)
 
 	// UpdateJobStatus puts job in backlog for a while.
-	UpdateJobStatus(job *api.JobInfo) (*api.JobInfo, error)
+	UpdateJobStatus(job *api.JobInfo, updatePG bool) (*api.JobInfo, error)
 
 	// AllocateVolumes allocates volume on the host to the task
 	AllocateVolumes(task *api.TaskInfo, hostname string) error

--- a/pkg/scheduler/framework/job_updater.go
+++ b/pkg/scheduler/framework/job_updater.go
@@ -1,0 +1,122 @@
+package framework
+
+import (
+	"context"
+	"math/rand"
+	"reflect"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
+)
+
+const (
+	jobUpdaterWorker = 16
+
+	jobConditionUpdateTime       = time.Minute
+	jobConditionUpdateTimeJitter = 30 * time.Second
+)
+
+// TimeJitterAfter means: new after old + duration + jitter
+func TimeJitterAfter(new, old time.Time, duration, maxJitter time.Duration) bool {
+	var jitter int64
+	if maxJitter > 0 {
+		jitter = rand.Int63n(int64(maxJitter))
+	}
+	return new.After(old.Add(duration + time.Duration(jitter)))
+}
+
+type jobUpdater struct {
+	ssn      *Session
+	jobQueue []*api.JobInfo
+}
+
+func newJobUpdater(ssn *Session) *jobUpdater {
+	queue := make([]*api.JobInfo, 0, len(ssn.Jobs))
+	for _, job := range ssn.Jobs {
+		queue = append(queue, job)
+	}
+
+	ju := &jobUpdater{
+		ssn:      ssn,
+		jobQueue: queue,
+	}
+	return ju
+}
+
+func (ju *jobUpdater) UpdateAll() {
+	workqueue.ParallelizeUntil(context.TODO(), jobUpdaterWorker, len(ju.jobQueue), ju.updateJob)
+}
+
+func isPodGroupConditionsUpdated(newCondition, oldCondition []v1alpha1.PodGroupCondition) bool {
+	if len(newCondition) != len(oldCondition) {
+		return true
+	}
+
+	for index, newCond := range newCondition {
+		oldCond := oldCondition[index]
+
+		newTime := newCond.LastTransitionTime
+		oldTime := oldCond.LastTransitionTime
+		if TimeJitterAfter(newTime.Time, oldTime.Time, jobConditionUpdateTime, jobConditionUpdateTimeJitter) {
+			return true
+		}
+
+		// if newCond is not new enough, we treat it the same as the old one
+		newCond.LastTransitionTime = oldTime
+
+		// comparing should ignore the TransitionID
+		newTransitionID := newCond.TransitionID
+		newCond.TransitionID = oldCond.TransitionID
+
+		shouldUpdate := !reflect.DeepEqual(&newCond, &oldCond)
+
+		newCond.LastTransitionTime = newTime
+		newCond.TransitionID = newTransitionID
+		if shouldUpdate {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isPodGroupStatusUpdated(newStatus, oldStatus *v1alpha1.PodGroupStatus) bool {
+	newCondition := newStatus.Conditions
+	newStatus.Conditions = nil
+	oldCondition := oldStatus.Conditions
+	oldStatus.Conditions = nil
+
+	shouldUpdate := !reflect.DeepEqual(newStatus, oldStatus) || isPodGroupConditionsUpdated(newCondition, oldCondition)
+
+	newStatus.Conditions = newCondition
+	oldStatus.Conditions = oldCondition
+
+	return shouldUpdate
+}
+
+// updateJob update specified job
+func (ju *jobUpdater) updateJob(index int) {
+	job := ju.jobQueue[index]
+	ssn := ju.ssn
+
+	// If job is using PDB, ignore it.
+	// TODO(k82cn): remove it when removing PDB support
+	if job.PodGroup == nil {
+		ssn.cache.RecordJobStatusEvent(job)
+		return
+	}
+
+	job.PodGroup.Status = jobStatus(ssn, job)
+	oldStatus, found := ssn.podGroupStatus[job.UID]
+	updatePG := !found || isPodGroupStatusUpdated(&job.PodGroup.Status, oldStatus)
+
+	if _, err := ssn.cache.UpdateJobStatus(job, updatePG); err != nil {
+		glog.Errorf("Failed to update job <%s/%s>: %v",
+			job.Namespace, job.Name, err)
+	}
+}

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -54,6 +54,7 @@ type Session struct {
 	taskOrderFns      map[string]api.CompareFn
 	predicateFns      map[string]api.PredicateFn
 	nodeOrderFns      map[string]api.NodeOrderFn
+	batchNodeOrderFns map[string]api.BatchNodeOrderFn
 	nodeMapFns        map[string]api.NodeMapFn
 	nodeReduceFns     map[string]api.NodeReduceFn
 	preemptableFns    map[string]api.EvictableFn
@@ -82,6 +83,7 @@ func openSession(cache cache.Cache) *Session {
 		taskOrderFns:      map[string]api.CompareFn{},
 		predicateFns:      map[string]api.PredicateFn{},
 		nodeOrderFns:      map[string]api.NodeOrderFn{},
+		batchNodeOrderFns: map[string]api.BatchNodeOrderFn{},
 		nodeMapFns:        map[string]api.NodeMapFn{},
 		nodeReduceFns:     map[string]api.NodeReduceFn{},
 		preemptableFns:    map[string]api.EvictableFn{},

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -39,10 +39,12 @@ type PodLister struct {
 	TaskWithAffinity map[api.TaskID]*api.TaskInfo
 }
 
+// PodAffinityLister is used to list pod with affinity
 type PodAffinityLister struct {
 	pl *PodLister
 }
 
+// HaveAffinity checks pod have affinity or not
 func HaveAffinity(pod *v1.Pod) bool {
 	affinity := pod.Spec.Affinity
 	return affinity != nil &&
@@ -51,6 +53,7 @@ func HaveAffinity(pod *v1.Pod) bool {
 			affinity.PodAntiAffinity != nil)
 }
 
+// NewPodLister returns a PodLister generate from ssn
 func NewPodLister(ssn *framework.Session) *PodLister {
 	pl := &PodLister{
 		Session: ssn,
@@ -161,6 +164,7 @@ func (pl *PodLister) AffinityFilteredList(podFilter algorithm.PodFilter, selecto
 	return pl.filteredListWithTaskSet(pl.TaskWithAffinity, podFilter, selector)
 }
 
+// AffinityLister generate a PodAffinityLister following current PodLister
 func (pl *PodLister) AffinityLister() *PodAffinityLister {
 	pal := &PodAffinityLister{
 		pl: pl,
@@ -178,6 +182,7 @@ func (pal *PodAffinityLister) FilteredList(podFilter algorithm.PodFilter, select
 	return pal.pl.AffinityFilteredList(podFilter, selector)
 }
 
+// GenerateNodeMapAndSlice returns the nodeMap and nodeSlice generated from ssn
 func GenerateNodeMapAndSlice(nodes map[string]*api.NodeInfo) (map[string]*cache.NodeInfo, []*v1.Node) {
 	var nodeMap map[string]*cache.NodeInfo
 	var nodeSlice []*v1.Node

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -19,9 +19,12 @@ package util
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
+	"k8s.io/kubernetes/pkg/scheduler/cache"
 
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/framework"
@@ -30,11 +33,33 @@ import (
 // PodLister is used in predicate and nodeorder plugin
 type PodLister struct {
 	Session *framework.Session
+
+	CachedPods       map[api.TaskID]*v1.Pod
+	Tasks            map[api.TaskID]*api.TaskInfo
+	TaskWithAffinity map[api.TaskID]*api.TaskInfo
 }
 
-// List method is used to list all the pods
-func (pl *PodLister) List(selector labels.Selector) ([]*v1.Pod, error) {
-	var pods []*v1.Pod
+type PodAffinityLister struct {
+	pl *PodLister
+}
+
+func HaveAffinity(pod *v1.Pod) bool {
+	affinity := pod.Spec.Affinity
+	return affinity != nil &&
+		(affinity.NodeAffinity != nil ||
+			affinity.PodAffinity != nil ||
+			affinity.PodAntiAffinity != nil)
+}
+
+func NewPodLister(ssn *framework.Session) *PodLister {
+	pl := &PodLister{
+		Session: ssn,
+
+		CachedPods:       make(map[api.TaskID]*v1.Pod),
+		Tasks:            make(map[api.TaskID]*api.TaskInfo),
+		TaskWithAffinity: make(map[api.TaskID]*api.TaskInfo),
+	}
+
 	for _, job := range pl.Session.Jobs {
 		for status, tasks := range job.TaskStatusIndex {
 			if !api.AllocatedStatus(status) {
@@ -42,16 +67,84 @@ func (pl *PodLister) List(selector labels.Selector) ([]*v1.Pod, error) {
 			}
 
 			for _, task := range tasks {
-				if selector.Matches(labels.Set(task.Pod.Labels)) {
-					if task.NodeName != task.Pod.Spec.NodeName {
-						pod := task.Pod.DeepCopy()
-						pod.Spec.NodeName = task.NodeName
-						pods = append(pods, pod)
-					} else {
-						pods = append(pods, task.Pod)
-					}
+				pl.Tasks[task.UID] = task
+				if HaveAffinity(task.Pod) {
+					pl.TaskWithAffinity[task.UID] = task
 				}
 			}
+		}
+	}
+
+	return pl
+}
+
+func (pl *PodLister) copyTaskPod(task *api.TaskInfo) *v1.Pod {
+	pod := task.Pod.DeepCopy()
+	pod.Spec.NodeName = task.NodeName
+	return pod
+}
+
+// GetPod will get pod with proper nodeName, from cache or DeepCopy
+// keeping this function read only to avoid concurrent panic of map
+func (pl *PodLister) GetPod(task *api.TaskInfo) *v1.Pod {
+	if task.NodeName == task.Pod.Spec.NodeName {
+		return task.Pod
+	}
+
+	pod, found := pl.CachedPods[task.UID]
+	if !found {
+		// we could not write the copied pod back into cache for read only
+		pod = pl.copyTaskPod(task)
+		glog.Warningf("DeepCopy for pod %s/%s at PodLister.GetPod is unexpected", pod.Namespace, pod.Name)
+	}
+	return pod
+}
+
+// UpdateTask will update the pod nodeName in cache using nodeName
+// NOT thread safe, please ensure UpdateTask is the only called function of PodLister at the same time.
+func (pl *PodLister) UpdateTask(task *api.TaskInfo, nodeName string) *v1.Pod {
+	pod, found := pl.CachedPods[task.UID]
+	if !found {
+		pod = pl.copyTaskPod(task)
+		pl.CachedPods[task.UID] = pod
+	}
+	pod.Spec.NodeName = nodeName
+
+	if !api.AllocatedStatus(task.Status) {
+		delete(pl.Tasks, task.UID)
+		if HaveAffinity(task.Pod) {
+			delete(pl.TaskWithAffinity, task.UID)
+		}
+	} else {
+		pl.Tasks[task.UID] = task
+		if HaveAffinity(task.Pod) {
+			pl.TaskWithAffinity[task.UID] = task
+		}
+	}
+
+	return pod
+}
+
+// List method is used to list all the pods
+func (pl *PodLister) List(selector labels.Selector) ([]*v1.Pod, error) {
+	var pods []*v1.Pod
+	for _, task := range pl.Tasks {
+		pod := pl.GetPod(task)
+		if selector.Matches(labels.Set(pod.Labels)) {
+			pods = append(pods, pod)
+		}
+	}
+
+	return pods, nil
+}
+
+// FilteredList is used to list all the pods under filter condition
+func (pl *PodLister) filteredListWithTaskSet(taskSet map[api.TaskID]*api.TaskInfo, podFilter algorithm.PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
+	var pods []*v1.Pod
+	for _, task := range taskSet {
+		pod := pl.GetPod(task)
+		if podFilter(pod) && selector.Matches(labels.Set(pod.Labels)) {
+			pods = append(pods, pod)
 		}
 	}
 
@@ -60,28 +153,42 @@ func (pl *PodLister) List(selector labels.Selector) ([]*v1.Pod, error) {
 
 // FilteredList is used to list all the pods under filter condition
 func (pl *PodLister) FilteredList(podFilter algorithm.PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
-	var pods []*v1.Pod
-	for _, job := range pl.Session.Jobs {
-		for status, tasks := range job.TaskStatusIndex {
-			if !api.AllocatedStatus(status) {
-				continue
-			}
+	return pl.filteredListWithTaskSet(pl.Tasks, podFilter, selector)
+}
 
-			for _, task := range tasks {
-				if podFilter(task.Pod) && selector.Matches(labels.Set(task.Pod.Labels)) {
-					if task.NodeName != task.Pod.Spec.NodeName {
-						pod := task.Pod.DeepCopy()
-						pod.Spec.NodeName = task.NodeName
-						pods = append(pods, pod)
-					} else {
-						pods = append(pods, task.Pod)
-					}
-				}
-			}
-		}
+// AffinityFilteredList is used to list all the pods with affinity under filter condition
+func (pl *PodLister) AffinityFilteredList(podFilter algorithm.PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
+	return pl.filteredListWithTaskSet(pl.TaskWithAffinity, podFilter, selector)
+}
+
+func (pl *PodLister) AffinityLister() *PodAffinityLister {
+	pal := &PodAffinityLister{
+		pl: pl,
 	}
+	return pal
+}
 
-	return pods, nil
+// List method is used to list all the pods
+func (pal *PodAffinityLister) List(selector labels.Selector) ([]*v1.Pod, error) {
+	return pal.pl.List(selector)
+}
+
+// FilteredList is used to list all the pods with affinity under filter condition
+func (pal *PodAffinityLister) FilteredList(podFilter algorithm.PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
+	return pal.pl.AffinityFilteredList(podFilter, selector)
+}
+
+func GenerateNodeMapAndSlice(nodes map[string]*api.NodeInfo) (map[string]*cache.NodeInfo, []*v1.Node) {
+	var nodeMap map[string]*cache.NodeInfo
+	var nodeSlice []*v1.Node
+	nodeMap = make(map[string]*cache.NodeInfo)
+	for _, node := range nodes {
+		nodeInfo := cache.NewNodeInfo(node.Pods()...)
+		nodeInfo.SetNode(node.Node)
+		nodeMap[node.Name] = nodeInfo
+		nodeSlice = append(nodeSlice, node.Node)
+	}
+	return nodeMap, nodeSlice
 }
 
 // CachedNodeInfo is used in nodeorder and predicate plugin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The performance of volcano-scheduler is not so good at large scale cluster with many pods.

So, I try to improve it.

1. add QPS/Burst
2. add `ssn.JobValid` check before every action except `enqueue`.
3. remove lock in `cache.taskUnschedule`
4. add arguments `UpdatePG` in `cache.UpdateJobStatus` to avoid updating PG frequently
5. using `ParallelizeUntil` to accelerate JobStatus update in `closeSession`.
6. add cache to avoid re-generation of nodeInfo in nodeorder & predicates
7. add cache to avoid too many deepcopy for allocated pod
8. use event instead of lock in PodLister to refresh cached pod.
9. add `PodAffinityLister` to improve the performance of predicates. (assumed that pod without affinity will be affected by pod with affinity.)
10. add `runtime.GOMAXPROCS(runtime.NumCPU())`
11. add `BatchNodeOrderFn`, limit the computing of `nodeorder.InterPodAffinity`
12. add `podConditionHaveUpdate`, only updated condition would leads to event / deepcopy / update
13. add goroutine in `cache.Snapshot` to accelerate TaskInfo clone.
14. move `glog.Errorf` to `glog.V(3).Infof` in `util.PredicateNodes`
15. use eventClient instead of kubeClient to record event


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

